### PR TITLE
fmt, vet, minor cleanups and one nasty bug squash

### DIFF
--- a/config.go
+++ b/config.go
@@ -54,9 +54,9 @@ func parseConfig(data []byte) (Config, error) {
 // DeployConfig represents the key-value data in the _jekyll_s3.yml file
 // used for deploying a website to Amazon's S3.
 type DeployConfig struct {
-	Key    string `s3_id`
-	Secret string `s3_secret`
-	Bucket string `s3_bucket`
+	Key    string `s3_id:""`
+	Secret string `s3_secret:""`
+	Bucket string `s3_bucket:""`
 }
 
 // ParseDeployConfig will parse a YAML file at the given path and return

--- a/main.go
+++ b/main.go
@@ -86,7 +86,9 @@ func main() {
 	}
 
 	// Set any site variables that were overriden / provided in the cli args
-	if *baseurl != "" || site.Conf.Get("baseurl") == nil { site.Conf.Set("baseurl", *baseurl) }
+	if *baseurl != "" || site.Conf.Get("baseurl") == nil {
+		site.Conf.Set("baseurl", *baseurl)
+	}
 
 	// Generate the static website
 	if err := site.Generate(); err != nil {
@@ -181,7 +183,7 @@ func watch(site *Site) {
 		case ev := <-watcher.Event:
 			// Ignore changes to the _site directoy, hidden, or temp files
 			if !strings.HasPrefix(ev.Name, site.Dest) && !isHiddenOrTemp(ev.Name) {
-				fmt.Println("Event:", ev.Name)
+				fmt.Println("Event: ", ev.String())
 				recompile(site)
 			}
 		case err := <-watcher.Error:
@@ -193,8 +195,16 @@ func watch(site *Site) {
 func recompile(site *Site) {
 	mu.Lock()
 	defer mu.Unlock()
-	site.Reload()
-	site.Generate()
+
+	if err := site.Reload(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if err := site.Generate(); err != nil {
+		fmt.Println(err)
+		return
+	}
 }
 
 func logf(msg string, args ...interface{}) {

--- a/util.go
+++ b/util.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"os/exec"
-	"io"
 	"path/filepath"
 	"strings"
 )
@@ -12,8 +12,10 @@ import (
 // Appends the extension to the specified file. If the file already has the
 // desired extension no changes are made.
 func appendExt(fn, ext string) string {
-	if strings.HasSuffix(fn, ext) { return fn }
-	return fn + ext	
+	if strings.HasSuffix(fn, ext) {
+		return fn
+	}
+	return fn + ext
 }
 
 // Copies a file to the specified directory. It will also create any necessary
@@ -30,28 +32,28 @@ func copyTo(from, to string) error {
 
 // Returns True if a file has YAML front-end matter.
 func hasMatter(fn string) bool {
-	sample, _ := sniff(fn, 4)
+	sample, _ := sniff(strings.TrimLeft(fn, " \t\n"), 4)
 	return bytes.Equal(sample, []byte("---\n"))
 }
 
 // Returns True if the file is a temp file (starts with . or ends with ~).
 func isHiddenOrTemp(fn string) bool {
 	base := filepath.Base(fn)
-	return strings.HasPrefix(base, ".") || 
-				strings.HasPrefix(fn, ".") ||
-				strings.HasSuffix(base, "~") ||
-				fn == "README.md"
+	return strings.HasPrefix(base, ".") ||
+		strings.HasPrefix(fn, ".") ||
+		strings.HasSuffix(base, "~") ||
+		fn == "README.md"
 }
 
 // Returns True if the file is a template. This is determine by the files
 // parent directory (_layout or _include) and the file type (markdown).
 func isTemplate(fn string) bool {
 	switch {
-	case !isHtml(fn) :
+	case !isHtml(fn):
 		return false
-	case strings.HasPrefix(fn, "_layouts") :
+	case strings.HasPrefix(fn, "_layouts"):
 		return true
-	case strings.HasPrefix(fn, "_includes") :
+	case strings.HasPrefix(fn, "_includes"):
 		return true
 	}
 	return false
@@ -61,7 +63,7 @@ func isTemplate(fn string) bool {
 // TODO change this to isMarkup and add .xml, .rss, .atom
 func isHtml(fn string) bool {
 	switch filepath.Ext(fn) {
-	case ".html", ".htm", ".xml", ".rss", ".atom" :
+	case ".html", ".htm", ".xml", ".rss", ".atom":
 		return true
 	}
 	return false
@@ -70,7 +72,7 @@ func isHtml(fn string) bool {
 // Returns True if the markup is Markdown.
 func isMarkdown(fn string) bool {
 	switch filepath.Ext(fn) {
-	case ".md", ".markdown" :
+	case ".md", ".markdown":
 		return true
 	}
 	return false
@@ -79,11 +81,11 @@ func isMarkdown(fn string) bool {
 // Returns True if the specified file is a Page.
 func isPage(fn string) bool {
 	switch {
-	case strings.HasPrefix(fn, "_") :
+	case strings.HasPrefix(fn, "_"):
 		return false
-	case !isMarkdown(fn) && !isHtml(fn) :
+	case !isMarkdown(fn) && !isHtml(fn):
 		return false
-	case !hasMatter(fn) :
+	case !hasMatter(fn):
 		return false
 	}
 	return true
@@ -92,11 +94,11 @@ func isPage(fn string) bool {
 // Returns True if the specified file is a Post.
 func isPost(fn string) bool {
 	switch {
-	case !strings.HasPrefix(fn, "_posts") :
+	case !strings.HasPrefix(fn, "_posts"):
 		return false
-	case !isMarkdown(fn) :
+	case !isMarkdown(fn):
 		return false
-	case !hasMatter(fn) :
+	case !hasMatter(fn):
 		return false
 	}
 	return true
@@ -116,7 +118,7 @@ func dirs(path string) (paths []string) {
 	site := filepath.Join(path, "_site")
 	filepath.Walk(path, func(fn string, fi os.FileInfo, err error) error {
 		switch {
-		case err != nil :
+		case err != nil:
 			return nil
 		case fi.IsDir() == false:
 			return nil
@@ -134,7 +136,7 @@ func dirs(path string) (paths []string) {
 // Removes the files extension. If the file has no extension the string is
 // returned without modification.
 func removeExt(fn string) string {
-	if ext := filepath.Ext(fn); len(ext)>0 {
+	if ext := filepath.Ext(fn); len(ext) > 0 {
 		return fn[:len(fn)-len(ext)]
 	}
 	return fn


### PR DESCRIPTION
Just started using jkl recently.

ran gofmt to cleanup

ran "go vet" which complained about a couple of minor errors, which are now fixed.

Ran into a nasty race condition bug where editing a layout while jkl runs with --server and --auto flags
leads to a crash. Not sure if other editors do this, but with vim, when a file is edited and saved, the editor
deletes the file before saving it.  When the delete event occurs, jkl tries to regenerate the site, but eventually crashes when pkg/text/template discovers there's no layout file.
Since the problem is generally transient we catch the error and propagate it up the change to main.recompile, which logs and otherwise ignores it.

Also added -- split categories and tags by comma separator and add each one separately.

I discovered the lack of splitting when trying to generate related posts, but I found the process too cumbersome to do in go template. I think more of the work needs to be done in jkl so the template doesn't have to contain too much
logic.  I'll scratch this itch when it gets strong enough
