### PR TITLE
page.GetString: ensure value can be converted to string, avoids panic.

### DIFF
--- a/page.go
+++ b/page.go
@@ -121,7 +121,10 @@ func (p Page) Get(key string) interface{} {
 // Gets a parameter value as a string. If none exists return an empty string.
 func (p Page) GetString(key string) (str string) {
 	if v, ok := p[key]; ok {
-		str = v.(string)
+		switch v.(type) {
+		case string:
+			str = v.(string)
+		}
 	}
 	return
 }


### PR DESCRIPTION
i hit this when i was converting an existing jekyll instance to jkl, and my templates were in a chaotic state of transition :) this probably wouldn't happen in normal use, but seems good to be safe just in case.
