### PR TITLE
Skips hidden directories

### DIFF
--- a/site.go
+++ b/site.go
@@ -147,6 +147,9 @@ func (s *Site) read() error {
 		case err != nil:
 			return nil
 
+		case fi.IsDir() && isHiddenOrTemp(fn):
+			return filepath.SkipDir
+
 		// Ignore directories
 		case fi.IsDir():
 			return nil

--- a/util.go
+++ b/util.go
@@ -120,6 +120,8 @@ func dirs(path string) (paths []string) {
 		switch {
 		case err != nil:
 			return nil
+		case fi.IsDir() && isHiddenOrTemp(fn):
+			return filepath.SkipDir
 		case fi.IsDir() == false:
 			return nil
 		case strings.HasPrefix(fn, site):


### PR DESCRIPTION
The file watcher should ignore hidden directories.
